### PR TITLE
1.3 dev

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -10,3 +10,4 @@ UseTab: Never
 BreakBeforeBraces: Allman
 NamespaceIndentation: All
 ColumnLimit: 100
+SortIncludes: false

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.19)
 
 PROJECT(rlh
-    VERSION 1.2
+    VERSION 1.3
     DESCRIPTION "A header only roguelike rendering library."
     LANGUAGES C
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,12 @@
 cmake_minimum_required(VERSION 3.19)
 
-option(RLH_BUILD_EXAMPLE "Build the example project" OFF)
-
 PROJECT(rlh
     VERSION 1.2
     DESCRIPTION "A header only roguelike rendering library."
     LANGUAGES C
 )
+
+option(RLH_BUILD_EXAMPLE "Build the example project" OFF)
 
 add_library(${PROJECT_NAME} INTERFACE
     "${CMAKE_CURRENT_SOURCE_DIR}/include/roguelike.h"

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,6 +1,7 @@
 # create the executable for the example
 set(RLH_EXAMPLE_SOURCE_FILES
-	"main.c"
+    "gld_impl.c"
+    "main.c"
 	"rlh_impl.c"
 	"stb_image_impl.c"
 )
@@ -20,6 +21,7 @@ target_link_libraries(rlh_example
         glad
         stb
         rlh
+        gld
 )
 # grab the content file paths
 set(RLH_ASSET_FILES

--- a/example/src/gld_impl.c
+++ b/example/src/gld_impl.c
@@ -1,0 +1,3 @@
+#include <glad/glad.h>
+#define GLD_IMPLEMENTATION
+#include <glDebug.h>

--- a/example/src/main.c
+++ b/example/src/main.c
@@ -10,7 +10,7 @@ void gld_callback(const char* error, const char* func) { printf("%s: %s\n", erro
 int main()
 {
   GLD_SET_CALLBACK(gld_callback);
-  
+
   if (!glfwInit())
   {
     printf("GLFW failed to initialize!\n");

--- a/example/src/main.c
+++ b/example/src/main.c
@@ -5,10 +5,7 @@
 #include <stb_image.h>
 #include <string.h>
 
-void gld_callback(const char* error, const char* func)
-{
-  printf("%s: %s\n", error, func);
-}
+void gld_callback(const char* error, const char* func) { printf("%s: %s\n", error, func); }
 
 int main()
 {

--- a/example/src/main.c
+++ b/example/src/main.c
@@ -5,18 +5,32 @@
 #include <stb_image.h>
 #include <string.h>
 
+// if glDebug.h comes across an error, we want it sent to this callback for printing
 void gld_callback(const char* error, const char* func) { printf("%s: %s\n", error, func); }
 
 int main()
 {
+  // calculate some constant values that we will need to size the terminal and the window
+  const int tiles_wide = 40; // the amount of tiles wide and tall we want drawn in the terminal
+  const int tiles_tall = 25;
+  const int tile_width = 8; // the width and height of each terimal tile
+  const int tile_height = 8;
+  const float pixel_scale = 2; // the ratio of terminal pixels to window pixels
+  const int border_pixels = 32; // this is the size of the gap between edges of the terminal and the window edges
+  const int w_width = (tiles_wide * tile_width * pixel_scale) + (border_pixels * 2);
+  const int w_height = (tiles_tall * tile_height * pixel_scale) + (border_pixels * 2);
+
+  // set the debug callback for glDebug.h
   GLD_SET_CALLBACK(gld_callback);
 
+  // initialize the platform library
   if (!glfwInit())
   {
     printf("GLFW failed to initialize!\n");
     return 1;
   }
 
+  // configure the window
   glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
   glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
   glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
@@ -24,25 +38,16 @@ int main()
   glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GLFW_TRUE);
 #endif
   glfwWindowHint(GLFW_RESIZABLE, GLFW_FALSE);
-
-  const int tiles_wide = 40;
-  const int tiles_tall = 25;
-  const int tile_size = 8;
-  const float pixel_scale = 2;
-  const int border_pixels = 32;
-  const int w_width = (tiles_wide * tile_size * pixel_scale) + (border_pixels * 2);
-  const int w_height = (tiles_tall * tile_size * pixel_scale) + (border_pixels * 2);
-
+  // create the window
   GLFWwindow* window = glfwCreateWindow(w_width, w_height, "rlh test", NULL, NULL);
   glfwMakeContextCurrent(window);
-
   if (!window)
   {
     printf("window failed to be created!\n");
     glfwTerminate();
     return 2;
   }
-
+  // load opengl bindings
   if (!gladLoadGLLoader((GLADloadproc)glfwGetProcAddress))
   {
     glfwDestroyWindow(window);
@@ -51,11 +56,10 @@ int main()
     printf("failed to load opengl bindings!\n");
     return 3;
   }
-
+  // load the atlas image from secondary storage
   int i_width, i_height;
   stbi_set_flip_vertically_on_load(1);
   uint8_t* pixels = stbi_load("cp_8x8_rgba_bg_alpha.png", &i_width, &i_height, NULL, 4);
-
   if (!pixels)
   {
     glfwDestroyWindow(window);
@@ -68,6 +72,7 @@ int main()
   }
 
   // setup the stpqp coordinates for the atlas
+  // note that the atlas is a 16x16 grid of glyphs, with a total of 256
   const int sheet_sprite_dimensions = 16;
   const int sheet_sprite_count = sheet_sprite_dimensions * sheet_sprite_dimensions;
   const size_t stpqp_arr_size = sheet_sprite_count * sizeof(float) * 5;
@@ -102,7 +107,7 @@ int main()
       }
     }
   }
-
+  // create the roguelike.h atlas object
   rlhAtlas_h a = NULL;
   rlhresult_t result = rlhAtlasCreate(i_width, i_height, 1, pixels, 256, stpqp, &a);
   free(stpqp);
@@ -113,10 +118,10 @@ int main()
     printf("Error creating atlas: %s\n", RLH_RESULT_DESCRIPTIONS[result]);
     return 5;
   }
-
+  // create the roguelike.h terminal object
   rlhTerm_h t = NULL;
   result =
-      rlhTermCreateTileDimensions(tiles_wide, tiles_tall, pixel_scale, tile_size, tile_size, &t);
+      rlhTermCreateTileDimensions(tiles_wide, tiles_tall, pixel_scale, tile_width, tile_height, &t);
   if (result > RLH_RESULT_LAST_NON_ERROR)
   {
     rlhAtlasDestroy(a);
@@ -125,7 +130,7 @@ int main()
     printf("Error creating terminal: %s\n", RLH_RESULT_DESCRIPTIONS[result]);
     return 6;
   }
-
+  // the game loop
   while (!glfwWindowShouldClose(window))  // keep looping until the window is closed.
   {
     glfwPollEvents();  // poll for platform events to update the window with user input stuff
@@ -133,7 +138,7 @@ int main()
     // set the terminal background color to black by pushing a fill tile
     rlhTermPushFillTile(t, 0, RLH_TRANSPARENT, RLH_BLACK);
 
-    // every glyph in codepage 437
+    // every glyph in codepage 437 drawn to the upper left corner
     for (size_t x = 0; x < 16; x++)
     {
       for (size_t y = 0; y < 16; y++)
@@ -144,22 +149,23 @@ int main()
     }
 
     // half tile offset face on bottom right corner of codepage
-    rlhTermPushTileFree(t, 15 * tile_size + (tile_size / 2), 15 * tile_size + (tile_size / 2), 2,
+    rlhTermPushTileFree(t, 15 * tile_width + (tile_height / 2), 15 * tile_width + (tile_height / 2), 2,
                         RLH_WHITE, RLH_TRANSPARENT);
 
     // increasingly larger faces
-    rlhTermPushTileGridSized(t, 18, 5, tile_size * 5, tile_size * 5, 2, RLH_WHITE, RLH_TRANSPARENT);
-    rlhTermPushTileGridSized(t, 23, 5, tile_size * 4, tile_size * 4, 2, RLH_WHITE, RLH_TRANSPARENT);
-    rlhTermPushTileGridSized(t, 27, 5, tile_size * 3, tile_size * 3, 2, RLH_WHITE, RLH_TRANSPARENT);
-    rlhTermPushTileGridSized(t, 30, 5, tile_size * 2, tile_size * 2, 2, RLH_WHITE, RLH_TRANSPARENT);
-    rlhTermPushTileGridSized(t, 32, 5, tile_size, tile_size, 2, RLH_WHITE, RLH_TRANSPARENT);
+    rlhTermPushTileGridSized(t, 18, 5, tiletile_width_size * 5, tile_height * 5, 2, RLH_WHITE, RLH_TRANSPARENT);
+    rlhTermPushTileGridSized(t, 23, 5, tile_width * 4, tile_height * 4, 2, RLH_WHITE, RLH_TRANSPARENT);
+    rlhTermPushTileGridSized(t, 27, 5, tile_width * 3, tile_height * 3, 2, RLH_WHITE, RLH_TRANSPARENT);
+    rlhTermPushTileGridSized(t, 30, 5, tile_width * 2, tile_height * 2, 2, RLH_WHITE, RLH_TRANSPARENT);
+    rlhTermPushTileGridSized(t, 32, 5, tile_width, tile_height, 2, RLH_WHITE, RLH_TRANSPARENT);
 
     // big guy in corner going over edges
-    rlhTermPushTileFreeSized(t, -(tile_size * 3), 18 * tile_size, 15 * tile_size, 8 * tile_size, 2,
+    rlhTermPushTileFreeSized(t, -(tile_width * 3), 18 * tile_height, 15 * tile_width, 8 * tile_height, 2,
                              RLH_RED, RLH_TRANSPARENT);
 
+    // print some text to the screen
+    // this is easy to do because CP437 glyphs for characters collide with ascii character codes
     const size_t label_x = 18;
-
     const char* label_1 = "roguelike.h";
     const size_t label_1_y = 20;
     const size_t label_1_length = strlen(label_1);
@@ -180,16 +186,21 @@ int main()
     rlhViewport(0, 0, w_width, w_height);
     // draw clear color as silver
     rlhClearColor(RLH_SILVER);
+    // draw the terminal centered within the viewport.
+    // note that we made the terminal smaller than the window, so there will be space outside of it
     rlhTermDrawCentered(t, a, w_width, w_height);
-
+    // swap the window buffers. this presents the frame to the screen and reuses the framebuffer
+    // from the previous frame for the next draw
     glfwSwapBuffers(window);
   }
 
+  // destroy all roguelike.h resources
   rlhAtlasDestroy(a);
   a = NULL;
   rlhTermDestroy(t);
   t = NULL;
 
+  // destroy all platform library resources
   glfwDestroyWindow(window);
   window = NULL;
   glfwTerminate();

--- a/example/src/main.c
+++ b/example/src/main.c
@@ -154,7 +154,7 @@ int main()
                         2, RLH_WHITE, RLH_TRANSPARENT);
 
     // increasingly larger faces
-    rlhTermPushTileGridSized(t, 18, 5, tiletile_width_size * 5, tile_height * 5, 2, RLH_WHITE,
+    rlhTermPushTileGridSized(t, 18, 5, tile_width * 5, tile_height * 5, 2, RLH_WHITE,
                              RLH_TRANSPARENT);
     rlhTermPushTileGridSized(t, 23, 5, tile_width * 4, tile_height * 4, 2, RLH_WHITE,
                              RLH_TRANSPARENT);

--- a/example/src/main.c
+++ b/example/src/main.c
@@ -1,11 +1,19 @@
-#include <GLFW/glfw3.h>
 #include <glad/glad.h>
+#include <GLFW/glfw3.h>
+#include <glDebug.h>
 #include <roguelike.h>
 #include <stb_image.h>
 #include <string.h>
 
+void gld_callback(const char* error, const char* func)
+{
+  printf("%s: %s\n", error, func);
+}
+
 int main()
 {
+  GLD_SET_CALLBACK(gld_callback);
+  
   if (!glfwInit())
   {
     printf("GLFW failed to initialize!\n");

--- a/example/src/main.c
+++ b/example/src/main.c
@@ -1,5 +1,5 @@
-#include <glad/glad.h>
 #include <GLFW/glfw3.h>
+#include <glad/glad.h>
 #include <roguelike.h>
 #include <stb_image.h>
 #include <string.h>

--- a/example/src/main.c
+++ b/example/src/main.c
@@ -128,6 +128,8 @@ int main()
 
   while (!glfwWindowShouldClose(window))
   {
+    glfwPollEvents();  // poll for platform events to update the window with user input stuff
+
     // set the terminal background color to black by pushing a fill tile
     rlhTermPushFillTile(t, 0, RLH_TRANSPARENT, RLH_BLACK);
 
@@ -179,8 +181,6 @@ int main()
     // draw clear color as silver
     rlhClearColor(RLH_SILVER);
     rlhTermDrawCentered(t, a, w_width, w_height);
-
-    glfwPollEvents();
 
     glfwSwapBuffers(window);
   }

--- a/example/src/main.c
+++ b/example/src/main.c
@@ -126,7 +126,7 @@ int main()
     return 6;
   }
 
-  while (!glfwWindowShouldClose(window))
+  while (!glfwWindowShouldClose(window))  // keep looping until the window is closed.
   {
     glfwPollEvents();  // poll for platform events to update the window with user input stuff
 

--- a/example/src/main.c
+++ b/example/src/main.c
@@ -1,6 +1,6 @@
 #include <glad/glad.h>
-#include <GLFW/glfw3.h>
 #include <glDebug.h>
+#include <GLFW/glfw3.h>
 #include <roguelike.h>
 #include <stb_image.h>
 #include <string.h>

--- a/example/src/main.c
+++ b/example/src/main.c
@@ -11,12 +11,13 @@ void gld_callback(const char* error, const char* func) { printf("%s: %s\n", erro
 int main()
 {
   // calculate some constant values that we will need to size the terminal and the window
-  const int tiles_wide = 40; // the amount of tiles wide and tall we want drawn in the terminal
+  const int tiles_wide = 40;  // the amount of tiles wide and tall we want drawn in the terminal
   const int tiles_tall = 25;
-  const int tile_width = 8; // the width and height of each terimal tile
+  const int tile_width = 8;  // the width and height of each terimal tile
   const int tile_height = 8;
-  const float pixel_scale = 2; // the ratio of terminal pixels to window pixels
-  const int border_pixels = 32; // this is the size of the gap between edges of the terminal and the window edges
+  const float pixel_scale = 2;  // the ratio of terminal pixels to window pixels
+  const int border_pixels =
+      32;  // this is the size of the gap between edges of the terminal and the window edges
   const int w_width = (tiles_wide * tile_width * pixel_scale) + (border_pixels * 2);
   const int w_height = (tiles_tall * tile_height * pixel_scale) + (border_pixels * 2);
 
@@ -149,19 +150,23 @@ int main()
     }
 
     // half tile offset face on bottom right corner of codepage
-    rlhTermPushTileFree(t, 15 * tile_width + (tile_height / 2), 15 * tile_width + (tile_height / 2), 2,
-                        RLH_WHITE, RLH_TRANSPARENT);
+    rlhTermPushTileFree(t, 15 * tile_width + (tile_height / 2), 15 * tile_width + (tile_height / 2),
+                        2, RLH_WHITE, RLH_TRANSPARENT);
 
     // increasingly larger faces
-    rlhTermPushTileGridSized(t, 18, 5, tiletile_width_size * 5, tile_height * 5, 2, RLH_WHITE, RLH_TRANSPARENT);
-    rlhTermPushTileGridSized(t, 23, 5, tile_width * 4, tile_height * 4, 2, RLH_WHITE, RLH_TRANSPARENT);
-    rlhTermPushTileGridSized(t, 27, 5, tile_width * 3, tile_height * 3, 2, RLH_WHITE, RLH_TRANSPARENT);
-    rlhTermPushTileGridSized(t, 30, 5, tile_width * 2, tile_height * 2, 2, RLH_WHITE, RLH_TRANSPARENT);
+    rlhTermPushTileGridSized(t, 18, 5, tiletile_width_size * 5, tile_height * 5, 2, RLH_WHITE,
+                             RLH_TRANSPARENT);
+    rlhTermPushTileGridSized(t, 23, 5, tile_width * 4, tile_height * 4, 2, RLH_WHITE,
+                             RLH_TRANSPARENT);
+    rlhTermPushTileGridSized(t, 27, 5, tile_width * 3, tile_height * 3, 2, RLH_WHITE,
+                             RLH_TRANSPARENT);
+    rlhTermPushTileGridSized(t, 30, 5, tile_width * 2, tile_height * 2, 2, RLH_WHITE,
+                             RLH_TRANSPARENT);
     rlhTermPushTileGridSized(t, 32, 5, tile_width, tile_height, 2, RLH_WHITE, RLH_TRANSPARENT);
 
     // big guy in corner going over edges
-    rlhTermPushTileFreeSized(t, -(tile_width * 3), 18 * tile_height, 15 * tile_width, 8 * tile_height, 2,
-                             RLH_RED, RLH_TRANSPARENT);
+    rlhTermPushTileFreeSized(t, -(tile_width * 3), 18 * tile_height, 15 * tile_width,
+                             8 * tile_height, 2, RLH_RED, RLH_TRANSPARENT);
 
     // print some text to the screen
     // this is easy to do because CP437 glyphs for characters collide with ascii character codes

--- a/example/src/rlh_impl.c
+++ b/example/src/rlh_impl.c
@@ -1,3 +1,4 @@
 #include <glad/glad.h>
+#include <glDebug.h>
 #define RLH_IMPLEMENTATION
 #include <roguelike.h>

--- a/example/src/rlh_impl.c
+++ b/example/src/rlh_impl.c
@@ -1,4 +1,4 @@
-#include <glDebug.h>
 #include <glad/glad.h>
+#include <glDebug.h>
 #define RLH_IMPLEMENTATION
 #include <roguelike.h>

--- a/example/src/rlh_impl.c
+++ b/example/src/rlh_impl.c
@@ -1,4 +1,4 @@
-#include <glad/glad.h>
 #include <glDebug.h>
+#include <glad/glad.h>
 #define RLH_IMPLEMENTATION
 #include <roguelike.h>

--- a/include/roguelike.h
+++ b/include/roguelike.h
@@ -60,6 +60,7 @@
 
             #include <glad/glad.h> // you can use a different opengl loader here (see bellow)
             #include <glDebug.h> // this line is optional (see bellow)
+            #define RLH_RETAINED_MODE // optional (see bellow)
             #define RLH_IMPLEMENTATION
             #include <roguelike.h>
 
@@ -73,6 +74,13 @@
     header only library by including it before implementing roguelike.h. The glDebug.h library is
     avaliable here: https://github.com/Journeyman-dev/glDebug.h. Look at the comment on top of
     that header for more information about its usage.
+
+    By default, roguelike.h will clear the tile buffer after each draw. This requires you to set
+    all tiles over again the next frame from scratch. If you want to instead retain tiles from
+    previous draws unless you explicitly clear the tile buffer with the function
+    rlhTermClearTileData(), define RLH_RETAINED_MODE before implementing the header. If you do this,
+    be very careful! If you forget to clear the tile buffer and keep adding tiles to it over time,
+    this can result in a nasty memory leak.
 
     HOW TO DEBUG
     Many functions in roguelike.h return an enum value of type rlhresult_t. Result codes with

--- a/include/roguelike.h
+++ b/include/roguelike.h
@@ -241,7 +241,6 @@ extern "C"
 #  define GLD_CALL(glFunc) glFunc;
 #  define GLD_COMPILE(shaderHandleVar) glCompileShader(shaderHandleVar);
 #  define GLD_LINK(programHandleVar) glLinkProgram(programHandleVar);
-#  define GLD_END()
 #endif
 
   typedef struct rlhColor32_s
@@ -574,8 +573,6 @@ void main()\n\
     GLD_CALL(glTexImage3D(GL_TEXTURE_2D_ARRAY, 0, GL_RGBA8, pixel_width, pixel_height, page_count,
                           0, GL_RGBA, GL_UNSIGNED_BYTE, pixel_rgba));
 
-    GLD_END();
-
     return gl_texture_array;
   }
 
@@ -586,8 +583,6 @@ void main()\n\
     GLD_CALL(glClearColor((float)color.r / 255.0f, (float)color.g / 255.0f, (float)color.b / 255.0f,
                           (float)color.a / 255.0f));
     GLD_CALL(glClear(GL_COLOR_BUFFER_BIT));
-
-    GLD_END();
   }
 
   void rlhViewport(const int x, const int y, const int width, const int height)
@@ -596,8 +591,6 @@ void main()\n\
 
     // set viewport
     GLD_CALL(glViewport(x, y, width, height));
-
-    GLD_END();
   }
 
   rlhresult_t rlhAtlasCreate(const int atlas_pixel_width, const int atlas_pixel_height,
@@ -650,8 +643,6 @@ void main()\n\
     GLD_CALL(glGenTextures(1, &(*atlas)->FontmapTEX));
     GLD_CALL(glBindTexture(GL_TEXTURE_BUFFER, (*atlas)->FontmapTEX));
     GLD_CALL(glTexBuffer(GL_TEXTURE_BUFFER, GL_R32F, (*atlas)->FontmapBUF));
-
-    GLD_END();
 
     return RLH_RESULT_OK;
   }
@@ -715,8 +706,6 @@ void main()\n\
         glBufferData(GL_TEXTURE_BUFFER,
                      sizeof(float) * (GLsizei)atlas_glyph_count * RLH_FONTMAP_ELEMENTS_PER_GLYPH,
                      atlas_glyph_stpqp, GL_DYNAMIC_DRAW));
-
-    GLD_END();
 
     return RLH_RESULT_OK;
   }
@@ -859,8 +848,6 @@ void main()\n\
     GLD_CALL(glUniform1i(glGetUniformLocation((*term)->Program, "Fontmap"), 3));
     GLD_CALL(glUniform1i(glGetUniformLocation((*term)->Program, "Data"), 4));
 
-    GLD_END();
-
     return RLH_RESULT_OK;
   }
 
@@ -893,8 +880,6 @@ void main()\n\
     }
 
     GLD_CALL(glDeleteProgram(term->Program));
-
-    GLD_END();
 
     // free the struct
     free(term);
@@ -1209,8 +1194,6 @@ void main()\n\
     // set scissor
     GLD_CALL(glScissor(cropped_x, cropped_y, cropped_width, cropped_height));
     GLD_CALL(glEnable(GL_SCISSOR_TEST));
-
-    GLD_END();
   }
 
   rlhresult_t rlhTermDrawCentered(rlhTerm_h const term, rlhAtlas_h const atlas,
@@ -1255,8 +1238,6 @@ void main()\n\
     // unset the scissor
     GLD_CALL(glDisable(GL_SCISSOR_TEST));
 
-    GLD_END();
-
     return RLH_RESULT_OK;
   }
 
@@ -1285,8 +1266,6 @@ void main()\n\
 
     // unset the scissor
     GLD_CALL(glDisable(GL_SCISSOR_TEST));
-
-    GLD_END();
 
     return RLH_RESULT_OK;
   }
@@ -1348,8 +1327,6 @@ void main()\n\
 
       // DRAW!!!
       GLD_CALL(glDrawArrays(GL_TRIANGLES, 0, term->TileDataCount * RLH_VERTICES_PER_TILE));
-
-      GLD_END();
 
       // the tile data is automatically cleared after a draw as of 1.2 version. Reason for this
       // change is that it is was too easy to forget to clear manually and cause memory leaks.

--- a/include/roguelike.h
+++ b/include/roguelike.h
@@ -209,10 +209,17 @@
     declarations further down in this header file.
 
     CHANGELOG
+    - Version 1.3
+        Features
+            - Added option macro RLH_RETAINED_MODE to to disable automatic tile buffer clearing on each new frame. 
+            - Changed usage of glDebug.h to be consistent with version 1.0.
+        Tooling Changes
+            - Stopped the linter from auto-ordering includes, which was causing bugs to creep in just as fast as
+              they were fixed.
     - Version 1.2
         Features
             - Added automatic terminal clear after each draw so users don't have to remember
-            clear the data themselves to prevent memory leaks.
+              clear the data themselves to prevent memory leaks.
             - Update the header comment in roguelike.h with a detailed explanation of usage.
             - Result codes have been reordered, and RLH_RESULT_LAST_NON_ERROR was added to make it
             easier to determine if a result code is an error or not.

--- a/include/roguelike.h
+++ b/include/roguelike.h
@@ -22,7 +22,7 @@
     The source for this library can be found on GitHub:
     https://github.com/Journeyman-dev/roguelike.h
 
-    FEATURES:
+    FEATURES
     - A performant batched terminal rendering system that is similliar to the renderer employed by
       the video game Dwarf Fortress:
     - The entire terminal is rendered in a single draw call.
@@ -40,7 +40,7 @@
     - Ability to render tiles offset from gridspace positions.
     - Ability to render tiles with custom width and height per tile.
 
-    HOW TO SETUP:
+    HOW TO SETUP
     The roguelike.h library can be included in your project in one of two different ways:
         - Copy and paste the roguelike.h file directly into your source tree.
         - Clone the GitHub as a git submodule to your project's repository, and use the roguelike.h.
@@ -74,7 +74,7 @@
     avaliable here: https://github.com/Journeyman-dev/glDebug.h. Look at the comment on top of
     that header for more information about its usage.
 
-    HOW TO DEBUG:
+    HOW TO DEBUG
     Many functions in roguelike.h return an enum value of type rlhresult_t. Result codes with
     names that start with RLH_RESULT_ERROR_ are returned if an error occured in the function's
     execution. These values are all greater than RLH_RESULT_LAST_NON_ERROR.
@@ -104,7 +104,7 @@
 
         rlmhColor32_s my_color = RLH_C32(127, 42, 245);
 
-    HOW TO USE:
+    HOW TO USE
     To use roguelike.h, you must bind it to an OpenGL context. There are many open source platform
     libraries for creating a window for rendering, including GLFW (https://www.glfw.org/) and SDL
     (https://www.libsdl.org/). An example of using GLFW is included in the roguelike.h repository on
@@ -200,7 +200,7 @@
     For more information about each roguelike.h function you can call, look for comments above their
     declarations further down in this header file.
 
-    CHANGELOG:
+    CHANGELOG
     - Version 1.2
         Features
             - Added automatic terminal clear after each draw so users don't have to remember

--- a/include/roguelike.h
+++ b/include/roguelike.h
@@ -58,8 +58,8 @@
     actually use it. To implement roguelike.h, create a new .c or .cpp file and write in it the
     following:
 
-            #include <glDebug.h> // this line is optional (see bellow)
             #include <glad/glad.h> // you can use a different opengl loader here (see bellow)
+            #include <glDebug.h> // this line is optional (see bellow)
             #define RLH_IMPLEMENTATION
             #include <roguelike.h>
 

--- a/include/roguelike.h
+++ b/include/roguelike.h
@@ -235,7 +235,7 @@ extern "C"
 #include <stdint.h>
 
 // If glDebug.h is not included, make the debug macros do nothing.
-#ifndef GL_DEBUG_H
+#ifndef GLD_H
 #  define GLD_START()
 #  define GLD_SET_CALLBACK(callback)
 #  define GLD_CALL(glFunc) glFunc;
@@ -834,14 +834,14 @@ void main()\n\
       int gl_vertex_shader, gl_fragment_shader;
       GLD_CALL(gl_vertex_shader = glCreateShader(GL_VERTEX_SHADER));
       GLD_CALL(glShaderSource(gl_vertex_shader, 1, &RLH_VERTEX_SOURCE, NULL));
-      GLD_COMPILE(gl_vertex_shader);
+      GLD_COMPILE(gl_vertex_shader, "rlh vertex shader");
       GLD_CALL(gl_fragment_shader = glCreateShader(GL_FRAGMENT_SHADER));
       GLD_CALL(glShaderSource(gl_fragment_shader, 1, &RLH_FRAGMENT_SOURCE, NULL));
-      GLD_COMPILE(gl_fragment_shader);
+      GLD_COMPILE(gl_fragment_shader, "rlh fragment shader");
       GLD_CALL((*term)->Program = glCreateProgram());
       GLD_CALL(glAttachShader((*term)->Program, gl_vertex_shader));
       GLD_CALL(glAttachShader((*term)->Program, gl_fragment_shader));
-      GLD_LINK((*term)->Program);
+      GLD_LINK((*term)->Program, "rlh shader program");
       GLD_CALL(glDetachShader((*term)->Program, gl_vertex_shader));
       GLD_CALL(glDetachShader((*term)->Program, gl_fragment_shader));
       GLD_CALL(glDeleteShader(gl_vertex_shader));

--- a/include/roguelike.h
+++ b/include/roguelike.h
@@ -17,7 +17,7 @@
 */
 
 /*
-    roguelike.h version 1.2.0
+    roguelike.h version 1.3.0
     Header only roguelike rendering library.
     The source for this library can be found on GitHub:
     https://github.com/Journeyman-dev/roguelike.h

--- a/include/roguelike.h
+++ b/include/roguelike.h
@@ -1328,10 +1328,10 @@ void main()\n\
       // DRAW!!!
       GLD_CALL(glDrawArrays(GL_TRIANGLES, 0, term->TileDataCount * RLH_VERTICES_PER_TILE));
 
-      // if we don't want to retain the tiles between each frame, clear them.
-      #if !defined(RLH_RETAINED_MODE)
+// if we don't want to retain the tiles between each frame, clear them.
+#  if !defined(RLH_RETAINED_MODE)
       rlhTermClearTileData(term);
-      #endif
+#  endif
     }
 
     return RLH_RESULT_OK;

--- a/include/roguelike.h
+++ b/include/roguelike.h
@@ -1328,12 +1328,10 @@ void main()\n\
       // DRAW!!!
       GLD_CALL(glDrawArrays(GL_TRIANGLES, 0, term->TileDataCount * RLH_VERTICES_PER_TILE));
 
-      // the tile data is automatically cleared after a draw as of 1.2 version. Reason for this
-      // change is that it is was too easy to forget to clear manually and cause memory leaks.
-      // Retained tui rendering is a rare use case for this library, so enforcing clear on draw is a
-      // good solution to prevent headache. If someone REALLY wants retained rendering, they can
-      // easily edit this file and remove the following line.
+      // if we don't want to retain the tiles between each frame, clear them.
+      #if !defined(RLH_RETAINED_MODE)
       rlhTermClearTileData(term);
+      #endif
     }
 
     return RLH_RESULT_OK;

--- a/include/roguelike.h
+++ b/include/roguelike.h
@@ -211,7 +211,7 @@
     CHANGELOG
     - Version 1.3
         Features
-            - Added option macro RLH_RETAINED_MODE to to disable automatic tile buffer clearing on each new frame. 
+            - Added option macro RLH_RETAINED_MODE to to disable automatic tile buffer clearing on each new frame.
             - Changed usage of glDebug.h to be consistent with version 1.0.
         Tooling Changes
             - Stopped the linter from auto-ordering includes, which was causing bugs to creep in just as fast as


### PR DESCRIPTION
- Add implementation macro 'RLH_RETAINED_MODE' option to disable automatic tile clearing on draw.
- Changed usage of glDebug.h to be consistent with version 1.0.
- Stopped the linter from auto-ordering includes, which was causing bugs to creep in just as fast as they were fixed.